### PR TITLE
Fixed seeding for data partitionning

### DIFF
--- a/src/decentralizepy/datasets/Celeba.py
+++ b/src/decentralizepy/datasets/Celeba.py
@@ -122,7 +122,9 @@ class Celeba(Dataset):
             self.sizes[-1] += 1.0 - frac * self.num_partitions
             logging.debug("Size fractions: {}".format(self.sizes))
 
-        my_clients = DataPartitioner(files, self.sizes).use(self.dataset_id)
+        my_clients = DataPartitioner(files, self.sizes, seed=self.random_seed).use(
+            self.dataset_id
+        )
         my_train_data = {"x": [], "y": []}
         self.clients = []
         self.num_samples = []

--- a/src/decentralizepy/datasets/Femnist.py
+++ b/src/decentralizepy/datasets/Femnist.py
@@ -122,7 +122,9 @@ class Femnist(Dataset):
             self.sizes[-1] += 1.0 - frac * self.num_partitions
             logging.debug("Size fractions: {}".format(self.sizes))
 
-        my_clients = DataPartitioner(files, self.sizes).use(self.dataset_id)
+        my_clients = DataPartitioner(files, self.sizes, seed=self.random_seed).use(
+            self.dataset_id
+        )
         my_train_data = {"x": [], "y": []}
         self.clients = []
         self.num_samples = []

--- a/src/decentralizepy/datasets/MovieLens.py
+++ b/src/decentralizepy/datasets/MovieLens.py
@@ -108,7 +108,7 @@ class MovieLens(Dataset):
         df_test = pd.DataFrame()
         for i in range(0, users_count):
             df_user = df_ratings[df_ratings["user_id"] == i + 1]
-            df_user_train = df_user.sample(frac=0.7)
+            df_user_train = df_user.sample(frac=0.7, random_state=self.random_seed)
             df_user_test = pd.concat([df_user, df_user_train]).drop_duplicates(
                 keep=False
             )

--- a/src/decentralizepy/datasets/Reddit.py
+++ b/src/decentralizepy/datasets/Reddit.py
@@ -126,7 +126,9 @@ class Reddit(Dataset):
             self.sizes[-1] += 1.0 - frac * self.num_partitions
             logging.debug("Size fractions: {}".format(self.sizes))
 
-        my_clients = DataPartitioner(files, self.sizes).use(self.dataset_id)
+        my_clients = DataPartitioner(files, self.sizes, seed=self.random_seed).use(
+            self.dataset_id
+        )
         my_train_data = {"x": [], "y": []}
         self.clients = []
         self.num_samples = []

--- a/src/decentralizepy/datasets/Shakespeare.py
+++ b/src/decentralizepy/datasets/Shakespeare.py
@@ -132,7 +132,9 @@ class Shakespeare(Dataset):
             self.sizes[-1] += 1.0 - frac * self.num_partitions
             logging.debug("Size fractions: {}".format(self.sizes))
 
-        my_clients = DataPartitioner(files, self.sizes).use(self.dataset_id)
+        my_clients = DataPartitioner(files, self.sizes, seed=self.random_seed).use(
+            self.dataset_id
+        )
         my_train_data = {"x": [], "y": []}
         self.clients = []
         self.num_samples = []


### PR DESCRIPTION
Fix of #11 with regards to data partition.

For validation sets, a seed cannot be provided to `np.random.choices()` (see the [documentation](https://numpy.org/doc/stable/reference/random/generated/numpy.random.choice.html)), but reproducibility should be handled by the following line:
https://github.com/sacs-epfl/decentralizepy/blob/170fc9eb1bf31d0559cf57917a311c3b575b1e16/src/decentralizepy/node/Node.py#L207