### PR TITLE
update get_neighbors for python >= 3.9

### DIFF
--- a/src/decentralizepy/node/EpidemicLearning/EL_Local.py
+++ b/src/decentralizepy/node/EpidemicLearning/EL_Local.py
@@ -48,7 +48,7 @@ class EL_Local(Node):
         plt.savefig(filename)
 
     def get_neighbors(self, node=None):
-        return set(self.rng.sample(self.my_neighbors, self.degree))
+        return set(self.rng.sample(list(self.my_neighbors), self.degree))
 
     def receive_DPSGD(self):
         return self.receive_channel("DPSGD", block=True)

--- a/src/decentralizepy/node/EpidemicLearning/EL_Local_Timeout.py
+++ b/src/decentralizepy/node/EpidemicLearning/EL_Local_Timeout.py
@@ -49,7 +49,7 @@ class EL_Local(Node):
         plt.savefig(filename)
 
     def get_neighbors(self, node=None):
-        return set(self.rng.sample(self.my_neighbors, self.degree))
+        return set(self.rng.sample(list(self.my_neighbors), self.degree))
 
     def receive_DPSGD(self):
         return self.receive_channel("DPSGD", block=False)


### PR DESCRIPTION
Fix for issue #13 

Quick fix that could lead to complexity issues because the conversion from set to list is made every time the method is called so
Nb of communication/steps * Nb of nodes calls

Might consider changing the data type of neighbors from sets to lists or having both data structures stored if the set type is required for other uses in the code